### PR TITLE
UNRW-549: Add caching headers to all resources.

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,8 +7,17 @@ var Hapi = require('hapi')
 var server = new Hapi.Server(
     {
         connections: {
-            routes: {cors: true},
-            router: {stripTrailingSlash: true}
+            routes: {
+              cache: {
+                // 7 days
+                expiresIn: 604800000,
+                privacy: 'public'
+              },
+              cors: true
+            },
+            router: {
+              stripTrailingSlash: true
+            }
         }
     }
 );

--- a/src/controllers/base.js
+++ b/src/controllers/base.js
@@ -21,7 +21,12 @@ module.exports = {
             };
             reply(json).type('application/hal+json');
         },
-        id: 'index'
+        id: 'index',
+        cache: {
+            // 1 hour
+            expiresIn: 3600000,
+            privacy: 'public'
+        }
     },
     missing: {
         description: '404/Not Found response',

--- a/src/plugins/embed/lib/controllers/base.js
+++ b/src/plugins/embed/lib/controllers/base.js
@@ -28,6 +28,11 @@ module.exports = {
             };
             reply(json).type('application/hal+json');
         },
-        id: 'v0'
+        id: 'v0',
+        cache: {
+            // 1 hour
+            expiresIn: 3600000,
+            privacy: 'public'
+        }
     }
 };

--- a/src/plugins/embed/lib/controllers/iframe.js
+++ b/src/plugins/embed/lib/controllers/iframe.js
@@ -13,7 +13,12 @@ module.exports = {
         },
         id: 'list-iframe',
         tags: [ 'api', 'iframe' ],
-        notes: 'Identify all widgets made available via the ReliefWeb Widgets library.'
+        notes: 'Identify all widgets made available via the ReliefWeb Widgets library.',
+        cache: {
+            // 1 hour
+            expiresIn: 3600000,
+            privacy: 'public'
+        }
     },
     widget: {
         description: 'Generate the iframe response for the requested widget type.',
@@ -42,6 +47,11 @@ module.exports = {
         },
         id: 'iframe',
         tags: [ 'api', 'iframe' ],
-        notes: 'Request the iFrame content for a specific widget as might be included in an oEmbed payload.'
+        notes: 'Request the iFrame content for a specific widget as might be included in an oEmbed payload.',
+        cache: {
+            // 5 seconds
+            expiresIn: 5000,
+            privacy: 'public'
+        }
     }
 };

--- a/src/plugins/embed/lib/controllers/oembed.js
+++ b/src/plugins/embed/lib/controllers/oembed.js
@@ -13,8 +13,12 @@ module.exports = {
         },
         id: 'list-oembed',
         tags: [ 'api', 'oembed' ],
-        notes: 'Identify all oembed types made available via the ReliefWeb Widgets library.'
-
+        notes: 'Identify all oembed types made available via the ReliefWeb Widgets library.',
+        cache: {
+            // 1 hour
+            expiresIn: 3600000,
+            privacy: 'public'
+        }
     },
     widget: {
         description: 'Generate the oembed response for the requested widget type.',
@@ -53,7 +57,11 @@ module.exports = {
         },
         id: 'oembed',
         tags: [ 'api', 'oembed' ],
-        notes: 'Request the oEmbed payload to be embedded by an oEmbed client..'
-
+        notes: 'Request the oEmbed payload to be embedded by an oEmbed client.',
+        cache: {
+            // 5 seconds
+            expiresIn: 5000,
+            privacy: 'public'
+        }
     }
 };

--- a/src/plugins/embed/lib/controllers/widgets.js
+++ b/src/plugins/embed/lib/controllers/widgets.js
@@ -12,7 +12,12 @@ module.exports = {
         },
         id: 'list-widget',
         tags: [ 'api', 'widget' ],
-        notes: 'These widgets are listed based on the rw-widget library, but they will not work if the widget template isn\'t added to rw-embed.'
+        notes: 'These widgets are listed based on the rw-widget library, but they will not work if the widget template isn\'t added to rw-embed.',
+        cache: {
+            // 1 hour
+            expiresIn: 3600000,
+            privacy: 'public'
+        }
     },
     widget: {
         description: 'Relay the core widget content from reliefweb-widgets.js',
@@ -31,6 +36,11 @@ module.exports = {
         },
         id: 'widget',
         tags: [ 'api', 'widget' ],
-        notes: 'Complete HTML document to be rended client-side by the rw-widget library.'
+        notes: 'Complete HTML document to be rended client-side by the rw-widget library.',
+        cache: {
+            // 5 seconds
+            expiresIn: 5000,
+            privacy: 'public'
+        }
     }
 };


### PR DESCRIPTION
Cross-posted with JIRA:

I have added HTTP caching headers to all resources in the embed service.
- By default, all resources will be marked for a 1 week max-age. This is what all the assets and libraries are  using. Note that these assets are also included using a cache buster, so as long as we increment package.json version somehow this should be fine.
- All "landing/glue" resources are set for 1 hour.
- All direct widget resources (individual instances of oembed, iframe, or widget) are set for 5 seconds.

@fillerwriter @jonnadams do these numbers seem reasonable for performance & developer/QA sanity?
